### PR TITLE
Restrict OpenSearch ingress ALBs to a specific security group

### DIFF
--- a/playgrounds/bubble-up-cluster/opensearch.yaml
+++ b/playgrounds/bubble-up-cluster/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchstaging/opensearch"
   tag: "3.1.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/chatbot-test/opensearch.yaml
+++ b/playgrounds/chatbot-test/opensearch.yaml
@@ -11,3 +11,9 @@ config:
         system_indices.enabled: true
       ml_commons:
         agent_framework_enabled: true
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/deep-research/opensearch.yaml
+++ b/playgrounds/deep-research/opensearch.yaml
@@ -29,3 +29,9 @@ resources:
   requests:
     cpu: "4"
     memory: "32Gi"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/generative-dashboards/opensearch.yaml
+++ b/playgrounds/generative-dashboards/opensearch.yaml
@@ -11,3 +11,9 @@ config:
         system_indices.enabled: false
       ml_commons:
         agent_framework_enabled: true
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/global-vis-annotations/opensearch.yaml
+++ b/playgrounds/global-vis-annotations/opensearch.yaml
@@ -3,3 +3,9 @@ replicas: 2
 image:
   repository: "opensearchstaging/opensearch"
   tag: "3.3.0"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/index-insight-cluster/opensearch.yaml
+++ b/playgrounds/index-insight-cluster/opensearch.yaml
@@ -13,3 +13,9 @@ plugins:
   installList:
     - https://github.com/ruanyl/osd-dev-env/releases/download/opensearch-ml-3.2.0.0-SNAPSHOT/opensearch-ml-3.2.0.0-SNAPSHOT.zip
     - https://github.com/Hailong-am/skills/releases/download/3.2-insight-logseq/opensearch-skills-3.2.0.0-SNAPSHOT.zip
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/mfe-poc/opensearch.yaml
+++ b/playgrounds/mfe-poc/opensearch.yaml
@@ -11,3 +11,9 @@ config:
         system_indices.enabled: false
       ml_commons:
         agent_framework_enabled: true
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/new-explore/opensearch.yaml
+++ b/playgrounds/new-explore/opensearch.yaml
@@ -17,3 +17,9 @@ resources:
   requests:
     cpu: "4"
     memory: "32Gi"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/node-22-wp-5/opensearch.yaml
+++ b/playgrounds/node-22-wp-5/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchproject/opensearch"
   tag: "3.4.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/nodejs-22/opensearch.yaml
+++ b/playgrounds/nodejs-22/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchproject/opensearch"
   tag: "3.4.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/olly3-data-source/opensearch.yaml
+++ b/playgrounds/olly3-data-source/opensearch.yaml
@@ -42,3 +42,9 @@ plugins:
     - https://github.com/Hailong-am/os-build/releases/download/3.5-reactor-netty4/transport-reactor-netty4-3.5.0-SNAPSHOT.zip
     - https://github.com/Hailong-am/os-build/releases/download/3.5-flight-rpc/arrow-flight-rpc-3.5.0-SNAPSHOT.zip
     - https://github.com/Hailong-am/os-build/releases/download/ppl35/opensearch-sql-3.5.0.0-SNAPSHOT.zip
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/olly3-playground/opensearch.yaml
+++ b/playgrounds/olly3-playground/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchstaging/opensearch"
   tag: "3.5.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/per-agent/opensearch.yaml
+++ b/playgrounds/per-agent/opensearch.yaml
@@ -23,3 +23,9 @@ plugins:
     - https://github.com/mingshl/ml-commons/releases/download/3.2.0.0-test/opensearch-ml-3.2.0.0-SNAPSHOT.zip
     - https://github.com/Hailong-am/skills/releases/download/3.2-insight-logseq/opensearch-skills-3.2.0.0-SNAPSHOT.zip
     - https://github.com/Hailong-am/sql/releases/download/patterns/opensearch-sql-3.2.0.0-SNAPSHOT.zip
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/playground-526/opensearch.yaml
+++ b/playgrounds/playground-526/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchproject/opensearch"
   tag: "3.6.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/ruanyl-dev/opensearch.yaml
+++ b/playgrounds/ruanyl-dev/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchstaging/opensearch"
   tag: "3.1.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/t2dash/opensearch.yaml
+++ b/playgrounds/t2dash/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchproject/opensearch"
   tag: "3.6.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/t2dashboardvis/opensearch.yaml
+++ b/playgrounds/t2dashboardvis/opensearch.yaml
@@ -4,3 +4,9 @@ image:
   repository: "opensearchproject/opensearch"
   tag: "3.6.0"
   pullPolicy: "Always"
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/test-owenwyk/opensearch.yaml
+++ b/playgrounds/test-owenwyk/opensearch.yaml
@@ -27,3 +27,9 @@ securityConfig:
               - GET
             /_cat/nodes:
               - GET
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"

--- a/playgrounds/variable/opensearch.yaml
+++ b/playgrounds/variable/opensearch.yaml
@@ -12,3 +12,9 @@ config:
         system_indices.enabled: false
       ml_commons:
         agent_framework_enabled: true
+
+# Restrict the OpenSearch ingress ALB to a specific security group (avoid public 0.0.0.0/0)
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
+    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"


### PR DESCRIPTION
## What
Add a `security-groups` annotation to the `opensearch` ingress of 20 playgrounds so their ALBs are restricted to a specific security group instead of being open to `0.0.0.0/0`.

## Why
The `charts/opensearch` chart defaults to an **internet-facing** ALB with **no `security-groups` annotation** → the ingress is reachable from `0.0.0.0/0` on ports 80/443. Most playgrounds inherited this open default. This restricts them to the same security group already used by `ml-playground`.

## Change
Minimal per-file override appended to each `opensearch.yaml`:
```yaml
ingress:
  annotations:
    alb.ingress.kubernetes.io/security-groups: sg-0f6042abc5948740a
    alb.ingress.kubernetes.io/manage-backend-security-group-rules: "true"
```
Helm merges this over the chart defaults, so `scheme` / `listen-ports` / `target-type` / `enabled` are preserved; only the security group is added. Matches the existing `ml-playground/opensearch.yaml`.

**20 playgrounds:** bubble-up-cluster, chatbot-test, csp-workspace-disabled, deep-research, generative-dashboards, global-vis-annotations, index-insight-cluster, mfe-poc, new-explore, node-22-wp-5, nodejs-22, olly3-data-source, olly3-playground, per-agent, playground-526, ruanyl-dev, t2dash, t2dashboardvis, test-owenwyk, variable.

**Skipped:** `future-playground` (`ingress.enabled: false`, not exposed), `ml-playground` (already set).

## Notes / follow-ups
- Consider setting this security group as the **chart default** in `charts/opensearch` (and `charts/opensearch-dashboards`) so future playgrounds are restricted by default.
- Please confirm `sg-0f6042abc5948740a` resolves in every target cluster/VPC before merge.